### PR TITLE
Fixed flux calculation

### DIFF
--- a/app/src/main/java/org/bitnp/netcheckin2/network/LoginHelper.java
+++ b/app/src/main/java/org/bitnp/netcheckin2/network/LoginHelper.java
@@ -279,7 +279,7 @@ public class LoginHelper {
             try {
                 result = Float.parseFloat(response);
                 Log.i(TAG, "Get balance " + result);
-                result /= 1024 * 1024 * 1024;
+                result /= 1000 * 1000 * 1000;
             }
             catch(NumberFormatException e){
                 result = 0;


### PR DESCRIPTION
ISP usually uses 10^3, instead of 2^10.